### PR TITLE
Fix for _csv.Error

### DIFF
--- a/ted_reader.py
+++ b/ted_reader.py
@@ -87,7 +87,7 @@ class MultiLingualAlignedCorpusReader(object):
 
     def read_from_single_file(self, path_, s_lang, t_lang):
         data_dict = defaultdict(list)
-        with open(path_, 'rb') as fp:
+        with open(path_, 'r') as fp:
             reader = csv.DictReader(fp, delimiter='\t', quoting=csv.QUOTE_NONE)
             for row in reader:
                 data_dict['source'].append(row[s_lang])


### PR DESCRIPTION
_csv.Error while running ted_reader.py (I ran it with the default _en_ro_ settings).
Error: `_csv.Error: iterator should return strings, not bytes (did you open the file in text mode?)`

This has been fixed in this pull request.